### PR TITLE
Show the correct global PSDK version (Fix #22)

### DIFF
--- a/lib/psdk/cli/configuration.rb
+++ b/lib/psdk/cli/configuration.rb
@@ -9,8 +9,11 @@ module Psdk
       # Filename of the project configuration
       PROJECT_CONFIGURATION_FILENAME = '.psdk-cli.yml'
 
+      # Path where all the global configuration are stored
+      PATH = ENV.fetch('PSDK_CLI_DIR', Dir.home || ENV['USERPROFILE'] || '~')
+
       # Filename of the global configuration
-      GLOBAL_CONFIGURATION_FILENAME = File.join(Dir.home || ENV['USERPROFILE'] || '~', '.psdk-cli/config.yml')
+      GLOBAL_CONFIGURATION_FILENAME = File.join(PATH, '.psdk-cli/config.yml')
 
       # Create a new configuration
       # @param hash [Hash] configuration hash

--- a/lib/psdk/helpers/psdk.rb
+++ b/lib/psdk/helpers/psdk.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative '../cli/configuration'
+
+module Psdk
+  module Cli
+    # Module holding all the utility to interact with PSDK repository
+    module PSDK
+      # Default URL to the PSDK repository
+      MAIN_REPOSITORY_URL = 'https://gitlab.com/pokemonsdk/pokemonsdk.git'
+
+      module_function
+
+      # Ensure the PSDK module is cloned
+      def ensure_repository_cloned
+        return if Dir.exist?(File.join(repository_path, '.git'))
+
+        res = system('git', 'clone', MAIN_REPOSITORY_URL, chdir: Configuration::PATH)
+        return if res
+
+        puts "[Error] Failed to setup pokemonsdk repository in `#{Configuration::PATH}`"
+        exit(1)
+      end
+
+      # Get the repository path
+      # @return [String]
+      def repository_path
+        return File.join(Configuration::PATH, 'pokemonsdk')
+      end
+    end
+  end
+end

--- a/lib/psdk/helpers/studio.rb
+++ b/lib/psdk/helpers/studio.rb
@@ -9,14 +9,18 @@ module Psdk
       module_function
 
       # Find and Save Pokemon studio path
-      def find_and_save_path
+      # @param type [:global | :local] where to save the located studio path
+      def find_and_save_path(type)
         locations = common_studio_location.select { |l| Dir.exist?(l) }
         binaries_locations = psdk_binaries_locations
         studio_path = locations.find { |l| binaries_locations.any? { |b| Dir.exist?(File.join(l, b)) } }
-        return ask_and_save_studio_path unless studio_path
+        unless studio_path
+          puts '[Error] failed to locate Pokemon Studio, please set it up manually'
+          exit(1)
+        end
 
         puts "\rLocated Pokemon Studio in `#{studio_path}`"
-        Configuration.get(:global).studio_path = studio_path
+        Configuration.get(type).studio_path = studio_path
         Configuration.save
       end
 
@@ -28,26 +32,6 @@ module Psdk
         return nil unless valid_path
 
         return File.join(path, valid_path)
-      end
-
-      # Ask and save Pokemon Studio path
-      def ask_and_save_studio_path
-        print "\rCould not automatically find Pokémon Studio path, please enter it:"
-        path = $stdin.gets.chomp
-        check_psdk_binaries_in_provided_location(path)
-        Configuration.get(:global).studio_path = path
-        Configuration.save
-      rescue ArgumentError
-        retry
-      end
-
-      # Check if a provided path contains the psdk-binaries
-      # @param path [String]
-      def check_psdk_binaries_in_provided_location(path)
-        return if psdk_binaries_locations.any? { |l| Dir.exist?(File.join(path, l)) }
-
-        puts 'Provided path does not contain psdk-binaries'
-        raise ArgumentError
       end
 
       # Get all the common Pokemon Studio location

--- a/lib/psdk/helpers/studio.rb
+++ b/lib/psdk/helpers/studio.rb
@@ -19,7 +19,7 @@ module Psdk
           exit(1)
         end
 
-        puts "\rLocated Pokemon Studio in `#{studio_path}`"
+        puts "Located Pokemon Studio in `#{studio_path}`"
         Configuration.get(type).studio_path = studio_path
         Configuration.save
       end

--- a/lib/psdk/helpers/version.rb
+++ b/lib/psdk/helpers/version.rb
@@ -16,7 +16,7 @@ module Psdk
         puts "psdk-cli v#{VERSION}"
         return if no_psdk_version
 
-        print 'Searching for PSDK version...'
+        print "Searching for PSDK version...\r"
         search_and_show_psdk_version
       end
 
@@ -39,7 +39,7 @@ module Psdk
       # @param psdk_path [String] Path to the PSDK repository
       def show_global_psdk_version(psdk_path)
         version_string = version_to_string(load_version_integer(psdk_path))
-        puts "\rGlobal PSDK version: #{version_string}       "
+        puts "Global PSDK version: #{version_string}       "
       end
 
       # Search and show the local PSDK version

--- a/lib/psdk/helpers/version.rb
+++ b/lib/psdk/helpers/version.rb
@@ -2,6 +2,7 @@
 
 require_relative '../cli/configuration'
 require_relative 'studio'
+require_relative 'psdk'
 
 module Psdk
   module Cli
@@ -27,22 +28,17 @@ module Psdk
 
       # Search and show the global PSDK version
       def search_and_show_global_psdk_version
-        global_config = Configuration.get(:global)
-        Studio.find_and_save_path if global_config.studio_path.empty?
-        psdk_binaries_path = Studio.psdk_binaries_path(global_config.studio_path)
-        return show_global_psdk_version(psdk_binaries_path) if psdk_binaries_path
-
-        puts "\r[Error] Current Pokemon Studio path does not contain psdk-binaries"
-        global_config.studio_path = ''
-        raise ArgumentError
-      rescue ArgumentError
-        retry
+        PSDK.ensure_repository_cloned
+        psdk_path = PSDK.repository_path
+        show_global_psdk_version(psdk_path)
+        git_data = load_git_data(psdk_path)
+        puts "Global PSDK git Target: #{git_data}"
       end
 
       # Show the global PSDK version
-      # @param psdk_binaries_path [String]
-      def show_global_psdk_version(psdk_binaries_path)
-        version_string = version_to_string(load_version_integer(File.join(psdk_binaries_path, 'pokemonsdk')))
+      # @param psdk_path [String] Path to the PSDK repository
+      def show_global_psdk_version(psdk_path)
+        version_string = version_to_string(load_version_integer(psdk_path))
         puts "\rGlobal PSDK version: #{version_string}       "
       end
 
@@ -62,7 +58,15 @@ module Psdk
 
       # Show that there's no local PSDK version
       def show_no_local_psdk_version
-        puts "Project PSDK Version: Studio's PSDK version"
+        Studio.find_and_save_path(:local) if Configuration.get(:local).studio_path.empty?
+        psdk_binaries_path = Studio.psdk_binaries_path(Configuration.get(:local).studio_path)
+        unless psdk_binaries_path
+          puts 'Project PSDK Version: Cannot locate Pokémon Studio or local repository...'
+          exit(1)
+        end
+
+        version_string = version_to_string(load_version_integer(File.join(psdk_binaries_path, 'pokemonsdk')))
+        puts "Project PSDK Version: #{version_string} (Pokémon Studio)"
       end
 
       # Load the Git data if any
@@ -72,8 +76,8 @@ module Psdk
         Dir.chdir(path) do
           return '' unless Dir.exist?('.git') || Dir.exist?('../.git')
 
-          commit = `git log --oneline -n 1`
-          branch = `git branch --show-current`
+          commit = `git log --oneline -n 1`.chomp
+          branch = `git branch --show-current`.chomp
           return "[#{branch}] #{commit}" unless branch.empty?
 
           return "[!detached] #{commit}"

--- a/spec/psdk/helpers/studio_spec.rb
+++ b/spec/psdk/helpers/studio_spec.rb
@@ -29,49 +29,6 @@ RSpec.describe Psdk::Cli::Studio do
     expect(Psdk::Cli::Studio.common_studio_location).to eq(options)
   end
 
-  it 'checks if psdk-binaries exists in provided location' do
-    allow(Dir).to receive(:exist?) { |path| path == '/path/resources/psdk-binaries' }
-
-    expect { Psdk::Cli::Studio.check_psdk_binaries_in_provided_location('/path') }.not_to raise_error
-  end
-
-  it 'raises ArgumentError if the psdk-binaries does not exists in provided location' do
-    allow(Dir).to receive(:exist?) { false }
-    expect(Psdk::Cli::Studio).to receive(:puts).with('Provided path does not contain psdk-binaries')
-
-    expect { Psdk::Cli::Studio.check_psdk_binaries_in_provided_location('/path') }.to raise_error(ArgumentError)
-  end
-
-  it 'asks for Studio path' do
-    configuration = Psdk::Cli::Configuration.new({})
-    allow(Dir).to receive(:exist?) { |path| path == '/path/resources/psdk-binaries' }
-    allow($stdin).to receive(:gets).and_return("/path\n")
-    expect(Psdk::Cli::Studio).to receive(:print).with(
-      "\rCould not automatically find Pokémon Studio path, please enter it:"
-    )
-    expect(Psdk::Cli::Configuration).to receive(:get).with(:global).and_return(configuration)
-    expect(configuration).to receive(:studio_path=).with('/path')
-    expect(Psdk::Cli::Configuration).to receive(:save)
-
-    Psdk::Cli::Studio.ask_and_save_studio_path
-  end
-
-  it 'asks for Studio path until a valid one is provided' do
-    configuration = Psdk::Cli::Configuration.new({})
-    i = 0
-    allow(Dir).to receive(:exist?) { |path| path == '/valid_path/resources/psdk-binaries' }
-    allow($stdin).to receive(:gets) { (i += 1) == 1 ? "/path\n" : "/valid_path\n" }
-    expect(Psdk::Cli::Studio).to receive(:puts).with('Provided path does not contain psdk-binaries').exactly(1).times
-    expect(Psdk::Cli::Studio).to(
-      receive(:print).with("\rCould not automatically find Pokémon Studio path, please enter it:").exactly(2).times
-    )
-    expect(Psdk::Cli::Configuration).to receive(:get).with(:global).and_return(configuration).exactly(1).times
-    expect(configuration).to receive(:studio_path=).with('/valid_path')
-    expect(Psdk::Cli::Configuration).to receive(:save)
-
-    Psdk::Cli::Studio.ask_and_save_studio_path
-  end
-
   it 'returns the psdk-binaries path based on studio path' do
     allow(Dir).to receive(:exist?) { |path| path == '/path/resources/psdk-binaries' }
 
@@ -94,28 +51,32 @@ RSpec.describe Psdk::Cli::Studio do
     expect(configuration).to receive(:studio_path=).with('/Applications/PokemonStudio.app')
     expect(Psdk::Cli::Configuration).to receive(:save)
 
-    Psdk::Cli::Studio.find_and_save_path
+    Psdk::Cli::Studio.find_and_save_path(:global)
   end
 
-  it 'ask Studio path if target folder does not contains psdk-binaries' do
+  it 'exits with error if target folder does not contains psdk-binaries' do
     valid_paths = ['/Applications/PokemonStudio.app']
     allow(Dir).to receive(:exist?) { |path| valid_paths.include?(path) }
-    expect(Psdk::Cli::Studio).not_to receive(:puts)
-    expect(Psdk::Cli::Configuration).not_to receive(:get).with(:global)
+    expect(Psdk::Cli::Configuration).not_to receive(:get).with(:local)
     expect(Psdk::Cli::Configuration).not_to receive(:save)
-    expect(Psdk::Cli::Studio).to receive(:ask_and_save_studio_path)
+    expect(Psdk::Cli::Studio).to receive(:exit).with(1) { raise 'exit 1' }
+    expect(Psdk::Cli::Studio).to receive(:puts).with(
+      '[Error] failed to locate Pokemon Studio, please set it up manually'
+    )
 
-    Psdk::Cli::Studio.find_and_save_path
+    expect { Psdk::Cli::Studio.find_and_save_path(:local) }.to raise_error(RuntimeError, 'exit 1')
   end
 
-  it 'ask Studio path if no common path is found' do
+  it 'exits with error Studio path if no common path is found' do
     allow(Dir).to receive(:exist?) { false }
-    expect(Psdk::Cli::Studio).not_to receive(:puts)
-    expect(Psdk::Cli::Configuration).not_to receive(:get).with(:global)
+    expect(Psdk::Cli::Configuration).not_to receive(:get).with(:local)
     expect(Psdk::Cli::Configuration).not_to receive(:save)
-    expect(Psdk::Cli::Studio).to receive(:ask_and_save_studio_path)
+    expect(Psdk::Cli::Studio).to receive(:exit).with(1) { raise 'exit 1' }
+    expect(Psdk::Cli::Studio).to receive(:puts).with(
+      '[Error] failed to locate Pokemon Studio, please set it up manually'
+    )
 
-    Psdk::Cli::Studio.find_and_save_path
+    expect { Psdk::Cli::Studio.find_and_save_path(:local) }.to raise_error(RuntimeError, 'exit 1')
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/psdk/helpers/studio_spec.rb
+++ b/spec/psdk/helpers/studio_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Psdk::Cli::Studio do
     valid_paths = ['/Applications/PokemonStudio.app',
                    '/Applications/PokemonStudio.app/Contents/Resources/psdk-binaries']
     allow(Dir).to receive(:exist?) { |path| valid_paths.include?(path) }
-    expect(Psdk::Cli::Studio).to receive(:puts).with("\rLocated Pokemon Studio in `/Applications/PokemonStudio.app`")
+    expect(Psdk::Cli::Studio).to receive(:puts).with('Located Pokemon Studio in `/Applications/PokemonStudio.app`')
     expect(Psdk::Cli::Configuration).to receive(:get).with(:global).and_return(configuration)
     expect(configuration).to receive(:studio_path=).with('/Applications/PokemonStudio.app')
     expect(Psdk::Cli::Configuration).to receive(:save)

--- a/spec/psdk/helpers/version_spec.rb
+++ b/spec/psdk/helpers/version_spec.rb
@@ -4,7 +4,7 @@
 RSpec.describe Psdk::Cli::Version do
   it 'only prints the cli version' do
     expect(Psdk::Cli::Version).to receive(:puts).with("psdk-cli v#{Psdk::Cli::VERSION}")
-    expect(Psdk::Cli::Version).not_to receive(:print).with('Searching for PSDK version...')
+    expect(Psdk::Cli::Version).not_to receive(:print).with("Searching for PSDK version...\r")
     expect(Psdk::Cli::Version).not_to receive(:search_and_show_global_psdk_version)
     expect(Psdk::Cli::Version).not_to receive(:search_and_show_local_psdk_version)
 
@@ -26,14 +26,14 @@ RSpec.describe Psdk::Cli::Version do
   it 'shows global version' do
     expect(File).to receive(:exist?).with('/psdk_repository_path/version.txt').and_return(true)
     expect(File).to receive(:read).with('/psdk_repository_path/version.txt').and_return('4256')
-    expect(Psdk::Cli::Version).to receive(:puts).with("\rGlobal PSDK version: 16.160       ")
+    expect(Psdk::Cli::Version).to receive(:puts).with('Global PSDK version: 16.160       ')
 
     Psdk::Cli::Version.show_global_psdk_version('/psdk_repository_path')
   end
 
   it 'shows global version even if version.txt was not found (unlikely)' do
     expect(File).to receive(:exist?).with('/psdk_repository_path/version.txt').and_return(false)
-    expect(Psdk::Cli::Version).to receive(:puts).with("\rGlobal PSDK version: 0       ")
+    expect(Psdk::Cli::Version).to receive(:puts).with('Global PSDK version: 0       ')
 
     Psdk::Cli::Version.show_global_psdk_version('/psdk_repository_path')
   end
@@ -150,7 +150,7 @@ RSpec.describe Psdk::Cli::Version do
 
   it 'shows calls the main show function when no_psdk_version=false' do
     expect(Psdk::Cli::Version).to receive(:puts).with("psdk-cli v#{Psdk::Cli::VERSION}")
-    expect(Psdk::Cli::Version).to receive(:print).with('Searching for PSDK version...')
+    expect(Psdk::Cli::Version).to receive(:print).with("Searching for PSDK version...\r")
     expect(Psdk::Cli::Version).to receive(:search_and_show_global_psdk_version)
     expect(Psdk::Cli::Version).to receive(:search_and_show_local_psdk_version)
 

--- a/spec/psdk/helpers/version_spec.rb
+++ b/spec/psdk/helpers/version_spec.rb
@@ -11,58 +11,31 @@ RSpec.describe Psdk::Cli::Version do
     Psdk::Cli::Version.run(true)
   end
 
-  it 'search global psdk version' do
-    configuration = Psdk::Cli::Configuration.new({})
-    expect(Psdk::Cli::Configuration).to receive(:get).with(:global).and_return(configuration)
-    expect(Psdk::Cli::Studio).to receive(:find_and_save_path) {
-      configuration.instance_variable_set(:@studio_path, '/path')
-    }
-    expect(Psdk::Cli::Studio).to receive(:psdk_binaries_path).and_return('/path/psdk-binaries')
-    expect(Psdk::Cli::Version).to receive(:show_global_psdk_version).with('/path/psdk-binaries')
-
-    Psdk::Cli::Version.search_and_show_global_psdk_version
-  end
-
-  it 'shows global version' do
-    allow(Dir).to receive(:exist?) { true }
-    configuration = Psdk::Cli::Configuration.new({ studio_path: '/path' })
-    expect(Psdk::Cli::Configuration).to receive(:get).with(:global).and_return(configuration)
-    expect(Psdk::Cli::Studio).to receive(:psdk_binaries_path).and_return('/path/psdk-binaries')
-    expect(Psdk::Cli::Version).to receive(:show_global_psdk_version).with('/path/psdk-binaries')
-
-    Psdk::Cli::Version.search_and_show_global_psdk_version
-  end
-
-  it 'retry if initial path was invalid' do
-    allow(Dir).to receive(:exist?) { true }
-    configuration = Psdk::Cli::Configuration.new({ studio_path: '/invalid_path' })
-    expect(Psdk::Cli::Configuration).to receive(:get).with(:global).and_return(configuration).exactly(2).times
-    allow(Psdk::Cli::Studio).to receive(:psdk_binaries_path) { |path| path == '/invalid_path' ? nil : '/path/psdk-binaries' }
-    expect(Psdk::Cli::Version).to receive(:show_global_psdk_version).with('/path/psdk-binaries')
-    expect(Psdk::Cli::Studio).to receive(:find_and_save_path) {
-      configuration.instance_variable_set(:@studio_path, '/path')
-    }
-    expect(configuration).to receive(:studio_path=).with('').and_call_original
-    expect(Psdk::Cli::Version).to receive(:puts).with(
-      "\r[Error] Current Pokemon Studio path does not contain psdk-binaries"
+  it 'search and show global psdk version based on cloned repository' do
+    expect(Psdk::Cli::PSDK).to receive(:ensure_repository_cloned)
+    expect(Psdk::Cli::PSDK).to receive(:repository_path).and_return('/psdk_repository_path')
+    expect(Psdk::Cli::Version).to receive(:show_global_psdk_version).with('/psdk_repository_path')
+    expect(Psdk::Cli::Version).to receive(:load_git_data).with('/psdk_repository_path').and_return(
+      '[development] aaaaaa commit'
     )
+    expect(Psdk::Cli::Version).to receive(:puts).with('Global PSDK git Target: [development] aaaaaa commit')
 
     Psdk::Cli::Version.search_and_show_global_psdk_version
   end
 
   it 'shows global version' do
-    expect(File).to receive(:exist?).with('/path/psdk-binaries/pokemonsdk/version.txt').and_return(true)
-    expect(File).to receive(:read).with('/path/psdk-binaries/pokemonsdk/version.txt').and_return('4256')
+    expect(File).to receive(:exist?).with('/psdk_repository_path/version.txt').and_return(true)
+    expect(File).to receive(:read).with('/psdk_repository_path/version.txt').and_return('4256')
     expect(Psdk::Cli::Version).to receive(:puts).with("\rGlobal PSDK version: 16.160       ")
 
-    Psdk::Cli::Version.show_global_psdk_version('/path/psdk-binaries')
+    Psdk::Cli::Version.show_global_psdk_version('/psdk_repository_path')
   end
 
-  it 'shows global version even if version.txt was not found' do
-    expect(File).to receive(:exist?).with('/path/psdk-binaries/pokemonsdk/version.txt').and_return(false)
+  it 'shows global version even if version.txt was not found (unlikely)' do
+    expect(File).to receive(:exist?).with('/psdk_repository_path/version.txt').and_return(false)
     expect(Psdk::Cli::Version).to receive(:puts).with("\rGlobal PSDK version: 0       ")
 
-    Psdk::Cli::Version.show_global_psdk_version('/path/psdk-binaries')
+    Psdk::Cli::Version.show_global_psdk_version('/psdk_repository_path')
   end
 
   it 'do not show local version if no project is configured' do
@@ -74,12 +47,55 @@ RSpec.describe Psdk::Cli::Version do
   end
 
   it 'shows "studio\'s version" if no local pokemonsdk folder exists' do
-    configuration = Psdk::Cli::Configuration.new({})
-    expect(Psdk::Cli::Configuration).to receive(:get).with(:local).and_return(configuration)
-    allow(Psdk::Cli::Configuration).to receive(:project_path).and_return('/project')
-    expect(Dir).to receive(:exist?).with('/project/pokemonsdk').and_return(false)
-    expect(Psdk::Cli::Version).to receive(:puts).with("Project PSDK Version: Studio's PSDK version")
+    allow(Dir).to receive(:exist?).with('/studio_path').and_return(true)
 
+    configuration = Psdk::Cli::Configuration.new({ studio_path: '/studio_path' })
+    allow(Psdk::Cli::Configuration).to receive(:get).with(:local).and_return(configuration)
+    allow(Psdk::Cli::Configuration).to receive(:project_path).and_return('/project')
+
+    expect(Dir).to receive(:exist?).with('/project/pokemonsdk').and_return(false)
+    expect(Psdk::Cli::Studio).to receive(:psdk_binaries_path).with('/studio_path').and_return(
+      '/studio_path/psdk-binaries'
+    )
+    expect(File).to receive(:exist?).with('/studio_path/psdk-binaries/pokemonsdk/version.txt').and_return(true)
+    expect(File).to receive(:read).with('/studio_path/psdk-binaries/pokemonsdk/version.txt').and_return('4256')
+
+    expect(Psdk::Cli::Version).to receive(:puts).with('Project PSDK Version: 16.160 (Pokémon Studio)')
+    Psdk::Cli::Version.search_and_show_local_psdk_version
+  end
+
+  it 'shows error for local project if Studio and repository are not found' do
+    allow(Dir).to receive(:exist?).with('/studio_path').and_return(true)
+
+    configuration = Psdk::Cli::Configuration.new({ studio_path: '/studio_path' })
+    allow(Psdk::Cli::Configuration).to receive(:get).with(:local).and_return(configuration)
+    allow(Psdk::Cli::Configuration).to receive(:project_path).and_return('/project')
+
+    expect(Dir).to receive(:exist?).with('/project/pokemonsdk').and_return(false)
+    expect(Psdk::Cli::Studio).to receive(:psdk_binaries_path).with('/studio_path').and_return(nil)
+
+    expect(Psdk::Cli::Version).to receive(:puts).with(
+      'Project PSDK Version: Cannot locate Pokémon Studio or local repository...'
+    )
+    expect(Psdk::Cli::Version).to receive(:exit).with(1) { raise 'exit 1' }
+    expect { Psdk::Cli::Version.search_and_show_local_psdk_version }.to raise_error(RuntimeError, 'exit 1')
+  end
+
+  it 'calls Studio.find_and_save_path if studio path is empty when searching local psdk version' do
+    configuration = Psdk::Cli::Configuration.new({})
+    allow(Dir).to receive(:exist?).with('/studio_path').and_return(true)
+    expect(Psdk::Cli::Studio).to receive(:find_and_save_path) { configuration.studio_path = '/studio_path' }
+    allow(Psdk::Cli::Configuration).to receive(:get).with(:local).and_return(configuration)
+    allow(Psdk::Cli::Configuration).to receive(:project_path).and_return('/project')
+
+    expect(Dir).to receive(:exist?).with('/project/pokemonsdk').and_return(false)
+    expect(Psdk::Cli::Studio).to receive(:psdk_binaries_path).with('/studio_path').and_return(
+      '/studio_path/psdk-binaries'
+    )
+    expect(File).to receive(:exist?).with('/studio_path/psdk-binaries/pokemonsdk/version.txt').and_return(true)
+    expect(File).to receive(:read).with('/studio_path/psdk-binaries/pokemonsdk/version.txt').and_return('4256')
+
+    expect(Psdk::Cli::Version).to receive(:puts).with('Project PSDK Version: 16.160 (Pokémon Studio)')
     Psdk::Cli::Version.search_and_show_local_psdk_version
   end
 


### PR DESCRIPTION
Fixes the behaviour, now clones PSDK into psdk-cli configuration directory and shows PSDK version of the clone as globale version.

<img width="524" height="78" alt="image" src="https://github.com/user-attachments/assets/5a6ec474-9e15-4e7f-8475-835f74c646bb" />
